### PR TITLE
Issue 8 fix - confidence field now showing 'Not available' when field not available on backend

### DIFF
--- a/src/components/Fhir/InsightsDetailButton.js
+++ b/src/components/Fhir/InsightsDetailButton.js
@@ -80,7 +80,7 @@ export default class InsightsDetailButton extends React.Component {
                                     </tr>
                                     <tr>
                                         <td><strong>Confidence</strong></td>
-                                        <td>{Number(details.confidence)*100}%</td>
+                                        <td>{isNaN(Number(details.confidence) * 100) ? "Not available" : Number(details.confidence) * 100 + "%"}</td>
                                     </tr>
                                 </tbody>
                                 : null }


### PR DESCRIPTION
Issue 8 fix - confidence field now showing 'Not available' instead of NaN% when field not available on backend