### PR TITLE
Issue 22 and related items fixes

### DIFF
--- a/src/components/PatientList/index.js
+++ b/src/components/PatientList/index.js
@@ -79,7 +79,7 @@ export class PatientList extends React.Component
             return key && this.props.selection[key] !== false;
         }
 
-        let offset = this.props.query.offset || 0
+        let offset = this.props.query.offset || (this.props.query.page !== null ? (this.props.query.page - 1) * this.props.query.limit : null) || 0;
         let items = this.props.query.bundle.entry || [];
         if (this.props.settings.renderSelectedOnly) {
             items = items.filter(isSelected);

--- a/src/lib/PatientSearch.js
+++ b/src/lib/PatientSearch.js
@@ -842,8 +842,8 @@ export default class PatientSearch
 
         // prepare the base options for the patient ajax request
         let options = {
-            url: (this.offset && this.cacheId) || this.page ? server.url : `${server.url}/Patient/_search`,
-            method: (this.offset && this.cacheId) || this.page ? "GET" : "POST",
+            url: `${server.url}/Patient/_search`,
+            method: "POST",
             processData: false,
             data,
             headers: {


### PR DESCRIPTION
Fixed the following issues for case where a FHIR server returned (in terms of pagination settings) by page instead of by page offset for /patient/_search;

1) Movement between pages not working correctly in the case where FHIR server persists a mixture of resources and not only patient resources.
2) For second and subsequent patient list pages, an individual patient link didn't link to correct patient details.
3) Prev/Next Patient buttons didn't always link to correct patient details.

@ranum - Feel free to pull this branch if you want to test ahead of generating next master docker image.