### PR TITLE
Issue 20: Decode the base64 encoded data - especially the data that was NLP'd

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "prop-types": "^15.5.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-json-view": "^1.21.3",
+    "react-modal": "^3.14.4",
     "react-redux": "^7.2.4",
     "react-router": "^4.0.0",
     "react-router-dom": "^4.0.0",

--- a/src/components/Fhir/Grid/index.js
+++ b/src/components/Fhir/Grid/index.js
@@ -1,6 +1,8 @@
 import React       from "react"
+import Modal from "react-modal";
+import JSONViewer from "react-json-view";
 import PropTypes   from "prop-types"
-import { getPath } from "../../../lib"
+import { getPath,base64decodeResource } from "../../../lib"
 import { connect } from "react-redux"
 
 /**
@@ -80,6 +82,23 @@ export class Grid extends React.Component
                         <button onClick={ () => window.open(url, "_blank", "noopener,noreferrer") }>
                             <i className="fa fa-eye fas fa-bold"/>
                         </button>
+                        <button onClick={() => this.setState({modalOpen: true,resourceForModal: base64decodeResource(res),})}>
+                            <i className="fa fa-eye fas fa-bold" />
+                        </button>
+                        <Modal
+                            isOpen={this.state.modalOpen}
+                            onRequestClose={() => this.setState({ modalOpen: false })}
+                            preventScroll={true}
+                        >
+                            <div>
+                                <JSONViewer
+                                    style={{ overflow: "scroll", height: "100%" }}
+                                    collapsed={false}
+                                    theme="monokai"
+                                    src={this.state.resourceForModal}
+                                />
+                            </div>{" "}
+                        </Modal>
                     </div>
                 </td>
             </tr>

--- a/src/components/Fhir/Grid/index.js
+++ b/src/components/Fhir/Grid/index.js
@@ -44,15 +44,7 @@ export class Grid extends React.Component
 
     renderResource(res, i)
     {
-        let url = `${this.props.settings.server.url}/${res.resourceType}/${res.id}`;
-        if (this.props.settings.fhirViewer.enabled) {
-            url = this.props.settings.fhirViewer.url +
-                (this.props.settings.fhirViewer.url.indexOf("?") > -1 ? "&" : "?") +
-                this.props.settings.fhirViewer.param + "=" +
-                encodeURIComponent(url);
-        } else {
-            url += "?_format=json&_pretty=true"
-        }
+        
 
         return (
             <tr key={i}>
@@ -79,9 +71,6 @@ export class Grid extends React.Component
                 }
                 <td>
                     <div className="text-primary text-center">
-                        <button onClick={ () => window.open(url, "_blank", "noopener,noreferrer") }>
-                            <i className="fa fa-eye fas fa-bold"/>
-                        </button>
                         <button onClick={() => this.setState({modalOpen: true,resourceForModal: base64decodeResource(res),})}>
                             <i className="fa fa-eye fas fa-bold" />
                         </button>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -105,6 +105,44 @@ export function getPath(obj, path = "") {
     .reduce((out, key) => (out ? out[key] : undefined), obj);
 }
 
+
+/**
+ * Base64 decodes data attributes for various resource types
+ * @param {Object} res The input resource json object
+ * @returns {Object} Decoded resource json object
+ */
+export function base64decodeResource(res) {
+  let decodedResource = JSON.parse(JSON.stringify(res));
+  switch (res.resourceType) {
+    case "DiagnosticReport":
+      decodedResource.presentedForm[0].data = atob(
+        decodedResource.presentedForm[0].data
+      );
+      break;
+    case "Condition":
+    case "AllergyIntolerance":
+    case "Immunization":
+      decodedResource.meta.extension[0].extension.forEach((item) => {
+        if (item.url == "http://ibm.com/fhir/cdm/insight/insight-entry") {
+          console.log("Eureka");
+          item.extension.forEach((item2) => {
+            if (
+              item2.url == "http://ibm.com/fhir/cdm/insight/evidence-detail"
+            ) {
+              item2.valueAttachment.data = JSON.parse(
+                atob(item2.valueAttachment.data)
+              );
+            }
+          });
+        }
+      });
+
+      break;
+  }
+
+  return decodedResource;
+}
+
 export function compileQueryString(params) {
   let query = [];
 


### PR DESCRIPTION
Reference -> https://github.com/Alvearie/patient-browser/issues/20

Removed feature of displaying json via opening up separate window or using FHIR viewer and instead introduced displaying resource json via React json view component rendered within modal by clicking on ‘eye’ icon. To close modal view you just need to click outside modal window or press ‘Esc’. Data is displayed decoded for following resource types currently;

Diagnostic Report [presentedForm data]
Condition [nlp insight evidence detail]
AllergyIntolerance [nlp insight evidence detail]
Immunisation [nlp insight evidence detail]

If/as other resources are identified that contain decoded data we should be able to update for same quickly.

@ewill00 - FYI, At the moment you can see it working here -> https://paul-dev.wh-health-patterns.dev.watson-health.ibm.com/patient-browser/#/