### PR TITLE
issue 29: fix click event on insights button

### DIFF
--- a/src/components/Fhir/InsightsDetailButton.js
+++ b/src/components/Fhir/InsightsDetailButton.js
@@ -40,7 +40,7 @@ export default class InsightsDetailButton extends React.Component {
             </button>
           }
           position="left center"
-          on={["hover", "click", "focus"]}
+          on="click"
         >
           <div className="drop-shadow panel panel-default">
             <div className="panel-heading">


### PR DESCRIPTION
Appears from documentation that you can't have multiple trigger events for pop-up, so changed to just have insights view rendering on button click and it closes when you click outside popup. So no action triggered on hover event.