### PR TITLE
Issue 34 fix

### DIFF
--- a/src/lib/PatientSearch.js
+++ b/src/lib/PatientSearch.js
@@ -527,13 +527,13 @@ export default class PatientSearch
                 String(this.sort).split(",").forEach(token => {
                     if (token.indexOf("-") === 0) {
                         params.push({
-                            name : "_sort:desc",
-                            value: token.substring(1)
+                            name : "_sort",
+                            value: token
                         })
                     }
                     else {
                         params.push({
-                            name : "_sort:asc",
+                            name : "_sort",
                             value: token
                         })
                     }


### PR DESCRIPTION
_sort doesn't use asc/desc modifiers since FHIR R4. For example ..
instead of _sort:asc and _sort:desc they moved the asc/desc hint to a value prefix, so instead of _sort:asc=_id it should be _sort=_id and instead of _sort:desc=_id it should be _sort=-_id. (note the minus before the param name _id)

There is still a bug where multiple sort parameters aren't handled by /Patient/_search and I've raised issue on FHIR for that here -> https://github.com/IBM/FHIR/issues/3389  